### PR TITLE
Detail form request example

### DIFF
--- a/Examples/form-request.md
+++ b/Examples/form-request.md
@@ -5,7 +5,7 @@ Bad:
 public function rules(): array
 {
     return [
-        'field1' => ['required', 'string'],
+        'field1' => ['required', "unique:{$model->getTable()},column_name,{$model->id}"],
         'field2' => ['required', 'integer'],
         'field3' => ['required', 'boolean'],
     ];
@@ -14,8 +14,24 @@ public function rules(): array
 
 Good:
 ```php
+// FormRequest
 public function rules(): array
 {
-    return app(MyFormRequest::class)->rules();
+    return static::baseRules($this->model);
+}
+
+public static function baseRules(Model $model): array
+{
+    return [
+        'field1' => ['required', "unique:{$model->getTable()},column_name,{$model->id}"],
+        'field2' => ['required', 'integer'],
+        'field3' => ['required', 'boolean'],
+    ];
+}
+
+// LivewireComponent
+protected function rules(): array
+{
+    return FormRequest::baseRules($this->model);
 }
 ```


### PR DESCRIPTION
The idea to have only one source for validation rules is nice. But when I tried to using it, there are 2 issues that I encountered:
* Using `app(FormRequest::class)` will trigger the validate whenever the `rules` function is called. I'm using full-page component, maybe that why I got this issue. But still I dont think resolve the `FormRequest` is a good idea.
* In `FormRequest`, we can access to the model that resolved during the request. But I dont know how to pass the model into FormRequest from `app()`.

I think its good to have extra static layer from `FormRequest`, where we can define and pass needed params, then get it wherever we want to.