### PR TITLE
Add icons good & bad in examples

### DIFF
--- a/Examples/computed-properties.md
+++ b/Examples/computed-properties.md
@@ -12,7 +12,7 @@ public function render(): View
 }
 ```
 
-Good:
+:heavy_check_mark: Good:
 ```php
 public function getCountriesProperty(): Collection
 {

--- a/Examples/computed-properties.md
+++ b/Examples/computed-properties.md
@@ -1,6 +1,6 @@
 ### 📦 Use computed properties to access database
 
-Bad:
+:x: Bad:
 ```php
 public function render(): View
 {

--- a/Examples/event-listeners-over-polling.md
+++ b/Examples/event-listeners-over-polling.md
@@ -7,7 +7,7 @@ Bad:
 </div>
 ```
 
-Good:
+:heavy_check_mark: Good:
 
 *In component to update:*
 ```php

--- a/Examples/event-listeners-over-polling.md
+++ b/Examples/event-listeners-over-polling.md
@@ -1,6 +1,6 @@
 ### ☔ Prefer to use event listeners over polling
 
-Bad:
+:x: Bad:
 ```html
 <div wire:poll>
     User Content

--- a/Examples/form-request.md
+++ b/Examples/form-request.md
@@ -1,6 +1,6 @@
 ### 🌎 Use Form Request rules for validation
 
-Bad:
+:x: Bad:
 ```php
 public function rules(): array
 {

--- a/Examples/form-request.md
+++ b/Examples/form-request.md
@@ -12,7 +12,7 @@ public function rules(): array
 }
 ```
 
-Good:
+:heavy_check_mark: Good:
 ```php
 public function rules(): array
 {

--- a/Examples/root-element.md
+++ b/Examples/root-element.md
@@ -6,7 +6,7 @@ Bad:
 <div class="content">Content</div>
 ```
 
-Good:
+:heavy_check_mark: Good:
 ```html
 <div>
     <h1>Component Name</h1>

--- a/Examples/root-element.md
+++ b/Examples/root-element.md
@@ -1,6 +1,6 @@
 ### 🌳 Always set up root element
 
-Bad:
+:x: Bad:
 ```html
 <h1>Component Name</h1>
 <div class="content">Content</div>

--- a/Examples/route-model-binding.md
+++ b/Examples/route-model-binding.md
@@ -9,7 +9,7 @@ public function mount(User $user): void
 }
 ```
 
-Bad:
+:x: Bad:
 ```html
 <livewire:profile :user="auth()->user()" /> 
 ```

--- a/Examples/route-model-binding.md
+++ b/Examples/route-model-binding.md
@@ -14,7 +14,7 @@ Bad:
 <livewire:profile :user="auth()->user()" /> 
 ```
 
-Good:
+:heavy_check_mark: Good:
 ```html
 <livewire:profile :user="auth()->user()->uuid" /> 
 ```

--- a/Examples/wire-model-modifiers.md
+++ b/Examples/wire-model-modifiers.md
@@ -5,7 +5,7 @@ Bad:
 <input wire:model="email">
 ```
 
-Good:
+:heavy_check_mark: Good:
 ```html
 <input wire:model.debounce.500ms="email">
 ```

--- a/Examples/wire-model-modifiers.md
+++ b/Examples/wire-model-modifiers.md
@@ -1,6 +1,6 @@
 ### 💡 Use *debounce*, *lazy* & *defer* wire:model's modifiers
 
-Bad:
+:x: Bad:
 ```html
 <input wire:model="email">
 ```


### PR DESCRIPTION
Added icons in the examples to make it easier to spot bad and good practices.
- icon :x: before "bad"
- icon :heavy_check_mark: before "good"

Screenshot example:
![image](https://user-images.githubusercontent.com/12556170/167476851-60ee4be3-356e-47c7-b2b3-b4e9a4f86e94.png)
