### PR TITLE
computed properties clarify

### DIFF
--- a/Examples/computed-properties.md
+++ b/Examples/computed-properties.md
@@ -2,13 +2,11 @@
 
 :x: Bad:
 ```php
-public function render(): View
+public function countries(): Collection
 {
-    $countries = Country::select('name', 'code')
+    return Country::select('name', 'code')
         ->orderBy('name')
         ->get();
-
-    return view('livewire.select-country', ['countries' => $countries]);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Instead of constantly [polling](https://laravel-livewire.com/docs/2.x/polling#po
 
 ---
 ### 📦 Use computed properties to access database
-You can use [computed properties](https://laravel-livewire.com/docs/2.x/properties#computed-properties) to avoid unnecessary database queries. Computed properties are cached within the component's lifecycle and do not perform additional SQL queries on individual request when using the resources in class or in blade view. This shouldn't be expected to avoid queries for subsequent requests.
+You can use [computed properties](https://laravel-livewire.com/docs/2.x/properties#computed-properties) to avoid unnecessary database queries. Computed properties are cached within the component's lifecycle and do not perform additional SQL queries on multiple calls in the component class or in the blade view.
 
 [Example](https://github.com/michael-rubel/livewire-best-practices/blob/main/Examples/computed-properties.md)
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Instead of constantly [polling](https://laravel-livewire.com/docs/2.x/polling#po
 
 ---
 ### 📦 Use computed properties to access database
-You can use [computed properties](https://laravel-livewire.com/docs/2.x/properties#computed-properties) to avoid unnecessary database queries. Computed properties are cached within the component's lifecycle and do not perform additional SQL queries on subsequent requests when updating the state of an already mounted component.
+You can use [computed properties](https://laravel-livewire.com/docs/2.x/properties#computed-properties) to avoid unnecessary database queries. Computed properties are cached within the component's lifecycle and do not perform additional SQL queries on individual request when using the resources in class or in blade view. This shouldn't be expected to avoid queries for subsequent requests.
 
 [Example](https://github.com/michael-rubel/livewire-best-practices/blob/main/Examples/computed-properties.md)
 


### PR DESCRIPTION
computed properties cache the resource/variable for the individual request only, not for subsequent requests.